### PR TITLE
Upgrade to .NET Core 6.0 and EF Core 6.0

### DIFF
--- a/service/Microsoft.DSX.ProjectTemplate.API/Microsoft.DSX.ProjectTemplate.API.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.API/Microsoft.DSX.ProjectTemplate.API.csproj
@@ -1,36 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
-    <Company>Microsoft</Company>
-    <Product />
-    <Authors>Devices Software Experiences</Authors>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>8.0</LangVersion>
+		<Company>Microsoft</Company>
+		<Product />
+		<Authors>Devices Software Experiences</Authors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.9.4" />
-    <PackageReference Include="NSwag.MSBuild" Version="13.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="9.0.0" />
+		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+		<PackageReference Include="NSwag.AspNetCore" Version="13.15.10" />
+		<PackageReference Include="NSwag.MSBuild" Version="13.9.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Command\Microsoft.DSX.ProjectTemplate.Command.csproj" />
-    <ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Data\Microsoft.DSX.ProjectTemplate.Data.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Command\Microsoft.DSX.ProjectTemplate.Command.csproj" />
+		<ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Data\Microsoft.DSX.ProjectTemplate.Data.csproj" />
+	</ItemGroup>
 
-  <!-- https://github.com/RicoSuter/NSwag/wiki/Assembly-loading#net-core -->
-  <!-- build TypeScript client and DTOs for this backend -->
-  <Target Name="NSwag" AfterTargets="Build">
-    <Exec Command="$(NSwagExe_Net50) run nswag.json /variables:Configuration=$(Configuration)" />
-  </Target>
+	<!-- https://github.com/RicoSuter/NSwag/wiki/Assembly-loading#net-core -->
+	<!-- build TypeScript client and DTOs for this backend -->
+	<Target Name="NSwag" AfterTargets="Build">
+		<Exec Command="$(NSwagExe_Net50) run nswag.json /variables:Configuration=$(Configuration)" />
+	</Target>
 
 </Project>

--- a/service/Microsoft.DSX.ProjectTemplate.API/Microsoft.DSX.ProjectTemplate.API.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.API/Microsoft.DSX.ProjectTemplate.API.csproj
@@ -10,11 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="9.0.0" />
-		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="MediatR" Version="10.0.1" />
+		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
 		<PackageReference Include="NSwag.AspNetCore" Version="13.15.10" />
-		<PackageReference Include="NSwag.MSBuild" Version="13.9.4">
+		<PackageReference Include="NSwag.MSBuild" Version="13.15.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/service/Microsoft.DSX.ProjectTemplate.API/nswag.json
+++ b/service/Microsoft.DSX.ProjectTemplate.API/nswag.json
@@ -7,7 +7,7 @@
       "msBuildProjectExtensionsPath": null,
       "configuration": "$(Configuration)",
       "runtime": null,
-      "targetFramework": "net5.0",
+      "targetFramework": "net6.0",
       "noBuild": true,
       "verbose": true,
       "workingDirectory": null,

--- a/service/Microsoft.DSX.ProjectTemplate.Command/Microsoft.DSX.ProjectTemplate.Command.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Command/Microsoft.DSX.ProjectTemplate.Command.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="9.0.0" />
+		<PackageReference Include="MediatR" Version="10.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>

--- a/service/Microsoft.DSX.ProjectTemplate.Command/Microsoft.DSX.ProjectTemplate.Command.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Command/Microsoft.DSX.ProjectTemplate.Command.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Authors>Devices Software Experiences</Authors>
-    <Company>Microsoft</Company>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>8.0</LangVersion>
+		<Authors>Devices Software Experiences</Authors>
+		<Company>Microsoft</Company>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="9.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Data\Microsoft.DSX.ProjectTemplate.Data.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.Data\Microsoft.DSX.ProjectTemplate.Data.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/service/Microsoft.DSX.ProjectTemplate.Data/Microsoft.DSX.ProjectTemplate.Data.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Data/Microsoft.DSX.ProjectTemplate.Data.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Authors>Devices Software Experiences</Authors>
-    <Company>Microsoft</Company>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>8.0</LangVersion>
+		<Authors>Devices Software Experiences</Authors>
+		<Company>Microsoft</Company>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Migrations\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Migrations\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.1" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="10.1.1" />
+		<PackageReference Include="MediatR" Version="9.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 
 </Project>

--- a/service/Microsoft.DSX.ProjectTemplate.Data/Microsoft.DSX.ProjectTemplate.Data.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Data/Microsoft.DSX.ProjectTemplate.Data.csproj
@@ -12,8 +12,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="10.1.1" />
-		<PackageReference Include="MediatR" Version="9.0.0" />
+		<PackageReference Include="AutoMapper" Version="11.0.1" />
+		<PackageReference Include="MediatR" Version="10.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/service/Microsoft.DSX.ProjectTemplate.Test/Microsoft.DSX.ProjectTemplate.Test.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Test/Microsoft.DSX.ProjectTemplate.Test.csproj
@@ -13,13 +13,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+		<PackageReference Include="FluentAssertions" Version="6.7.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="Moq" Version="4.15.2" />
+		<PackageReference Include="Moq" Version="4.18.1" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/service/Microsoft.DSX.ProjectTemplate.Test/Microsoft.DSX.ProjectTemplate.Test.csproj
+++ b/service/Microsoft.DSX.ProjectTemplate.Test/Microsoft.DSX.ProjectTemplate.Test.csproj
@@ -1,31 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
+		<IsPackable>false</IsPackable>
 
-    <LangVersion>8.0</LangVersion>
+		<LangVersion>8.0</LangVersion>
 
-    <Authors>Devices Software Experiences</Authors>
+		<Authors>Devices Software Experiences</Authors>
 
-    <Company>Microsoft</Company>
-  </PropertyGroup>
+		<Company>Microsoft</Company>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
-	<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.15.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Moq" Version="4.15.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.API\Microsoft.DSX.ProjectTemplate.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.DSX.ProjectTemplate.API\Microsoft.DSX.ProjectTemplate.API.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Why?
Update backend Nuget packages in preparation for any new projects that will use the project template.


What changed?
This PR modifies the following files: 

1. Project Template.API.csproj
---- nswag.json inside API.csproj
2. Project Template.Command.csproj
3. Project Template.Data.csproj
4. Project Template.Test.csproj

How tested?

1. Checkout branch 'upgrade_.NET_6.0'
2. Build Solution ---
![image](https://user-images.githubusercontent.com/105322362/168887569-14010fdc-56d2-4c0b-94f5-752486c39fbe.png)
3. Verify in Output - '========== Rebuild All: 4 succeeded, 0 failed, 0 skipped =========='
![image](https://user-images.githubusercontent.com/105322362/168887903-d58030be-fa55-47a1-8edb-32334cdf76e3.png)
